### PR TITLE
Change: use tls 1.3 instead of 1.2

### DIFF
--- a/cpp/src/common/http_client.cpp
+++ b/cpp/src/common/http_client.cpp
@@ -388,7 +388,7 @@ HanamiRequest::makeSingleRequest(std::string &response,
         int version = 11;
 
         // init ssl
-        ssl::context ctx(ssl::context::tlsv12_client);
+        ssl::context ctx(ssl::context::tlsv13_client);
         //load_root_certificates(ctx);
         //ctx.set_verify_mode(ssl::verify_peer);
 


### PR DESCRIPTION
## Description

Change: use tls 1.3 instead of 1.2

## Related Issues

- https://github.com/kitsudaiki/ToriiGateway/issues/5

## How it was tested?

- Tsugumi
